### PR TITLE
Migrate to Snakemake 8

### DIFF
--- a/bin/run_snake.sh
+++ b/bin/run_snake.sh
@@ -10,7 +10,7 @@
 
 cd $SLURM_SUBMIT_DIR
 
-snakemake_module="bbc2/snakemake/snakemake-7.25.0"
+snakemake_module="bbc2/snakemake/snakemake-8.25.2"
 
 module load $snakemake_module
 
@@ -27,7 +27,7 @@ snakemake \
 --latency-wait 20 \
 --use-envmodules \
 --jobs 100 \
---cluster "mkdir -p logs/{rule}; sbatch \
+--executor cluster-generic --cluster-generic-submit-cmd "mkdir -p logs/{rule}; sbatch \
 -p ${SLURM_JOB_PARTITION} \
 --export=ALL \
 --nodes 1 \

--- a/bin/run_snakemake_v7.sh
+++ b/bin/run_snakemake_v7.sh
@@ -1,0 +1,43 @@
+#!/bin/bash
+#SBATCH --export=NONE
+#SBATCH -J rnaseq_workflow
+#SBATCH -o rnaseq_workflow.o
+#SBATCH -e rnaseq_workflow.e
+#SBATCH --ntasks 1
+#SBATCH --time 120:00:00
+#SBATCH --mem=8G
+#SBATCH --partition=long
+
+cd $SLURM_SUBMIT_DIR
+
+snakemake_module="bbc2/snakemake/snakemake-7.25.0"
+
+module load $snakemake_module
+
+# make logs dir if it does not exist already. 
+logs_dir="logs/"
+[[ -d $logs_dir ]] || mkdir -p $logs_dir
+
+
+echo "Start snakemake workflow." >&1                   
+echo "Start snakemake workflow." >&2     
+
+snakemake \
+-p \
+--latency-wait 20 \
+--use-envmodules \
+--jobs 100 \
+--cluster "mkdir -p logs/{rule}; sbatch \
+-p ${SLURM_JOB_PARTITION} \
+--export=ALL \
+--nodes 1 \
+--ntasks-per-node {threads} \
+--mem={resources.mem_gb}G \
+-t 120:00:00 \
+-o logs/{rule}/{resources.log_prefix}.o \
+-e logs/{rule}/{resources.log_prefix}.e" # SLURM hangs if output dir does not exist, so we create it before running sbatch on the snakemake jobs.
+#--slurm \
+#--default-resources slurm_account=${SLURM_JOB_USER} slurm_partition=${SLURM_JOB_PARTITION}
+
+echo "snakemake workflow done." >&1                   
+echo "snakemake workflow done." >&2                

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -19,6 +19,8 @@ PE_or_SE: PE
 call_variants: False
 grouped_contigs: config/grouped_contigs.tsv 
 
+run_vis_bigwig : True
+
 ####################################################################
 # FOR MOST STANDARD USE CASES, THE BELOW DO NOT NEED TO BE CHANGED.#
 ####################################################################

--- a/workflow/Snakefile
+++ b/workflow/Snakefile
@@ -6,7 +6,7 @@ from snakemake.utils import validate, min_version
 import itertools
 
 ##### set minimum snakemake version #####
-min_version("7.25.0")
+min_version("8.25.2")
 
 ##### load config and sample sheets #####
 

--- a/workflow/Snakefile
+++ b/workflow/Snakefile
@@ -50,7 +50,7 @@ rule all:
     input:
         "results/multiqc/multiqc_report.html",
         expand("results/SummarizedExperiment/{pref}.rds", pref=['SummarizedExperiment', 'sce']),
-        expand("results/avg_bigwigs/{group}.unstr.bw", group=pd.unique(samples['group'])),
+        expand("results/avg_bigwigs/{group}.unstr.bw", group=pd.unique(samples['group'])) if (config["run_vis_bigwig"]) else [],
         "results/variant_calling/final/07a_variant_annot/all.merged.filt.PASS.snpeff.vcf.gz" if (config["call_variants"]) else [],
         "results/variant_calling/final/07b_snp_pca_and_dendro/snprelate.html" if (config["call_variants"]) else [],
 

--- a/workflow/Snakefile
+++ b/workflow/Snakefile
@@ -31,7 +31,7 @@ if not (valid_groups.all()):
 # read grouped contigs
 contigs_file = config["grouped_contigs"]
 contig_groups = pd.read_table(contigs_file)
-contig_groups['contigs'].replace('', np.nan, inplace=True) # unplaced_contigs can be empty for certain references.
+contig_groups['contigs'] = contig_groups['contigs'].replace('', np.nan) # unplaced_contigs can be empty for certain references.
 contig_groups.dropna(subset=['contigs'], inplace=True)
 
 # check chromosomes/contigs parsed correctly by comparing to fai.

--- a/workflow/rules/RNAseq.smk
+++ b/workflow/rules/RNAseq.smk
@@ -25,7 +25,12 @@ rule rename_fastqs:
     envmodules:
     shell:
         """
-        ln -sr {input} {output} 
+        # If the fastqs are not compressed, gzipped them with new name.
+        if ( file -L {input} | grep -q 'gzip compressed' ) ; then
+            ln -sr {input} {output} 
+        else
+            gzip -c {input} > {output}
+        fi
         """
 
 def trim_galore_input(wildcards):


### PR DESCRIPTION
The new module for Snakemake (8.25.2) has the plugin cluster-generic. It offers the same functionality of the --cluster flag that we use to submit jobs in run_snake.sh. I don't see any incompatibility between the versions apart from this.