### PR TITLE
Export count matrix from SummarizedExperiment

### DIFF
--- a/workflow/rules/RNAseq.smk
+++ b/workflow/rules/RNAseq.smk
@@ -251,7 +251,8 @@ rule SummarizedExperiment:
         sce="results/SummarizedExperiment/sce.rds",
         sizeFactors="results/SummarizedExperiment/DESeq2_sizeFactors_reciprocal.tsv",
         txi="results/SummarizedExperiment/txi.rds",
-        strandedness="results/SummarizedExperiment/inferred_strandedness.txt"
+        strandedness="results/SummarizedExperiment/inferred_strandedness.txt",
+        count_matrix="results/SummarizedExperiment/count_matrix.txt"
     benchmark:
         "benchmarks/SummarizedExperiment/SummarizedExperiment.txt"
     params:
@@ -266,5 +267,5 @@ rule SummarizedExperiment:
         log_prefix=lambda wildcards: "_".join(wildcards) if len(wildcards) > 0 else "log"
     shell:
         """
-        Rscript --vanilla workflow/scripts/make_sce.R {params.gtf} {params.orgdb} {params.renv_rproj_dir} {output.se} {output.sce} {output.sizeFactors} {output.txi} {output.strandedness}
+        Rscript --vanilla workflow/scripts/make_sce.R {params.gtf} {params.orgdb} {params.renv_rproj_dir} {output.se} {output.sce} {output.sizeFactors} {output.txi} {output.strandedness} {output.count_matrix}
         """

--- a/workflow/scripts/make_sce.R
+++ b/workflow/scripts/make_sce.R
@@ -8,6 +8,7 @@ out_sce <- args[5]
 out_sizeFactors <- args[6]
 out_txi <- args[7]
 out_strand <- args[8]
+out_count_matrix <- args[9]
 
 # use the packages in the renv
 renv::load(renv_rproj_dir)
@@ -165,6 +166,10 @@ count_data <- list(counts=raw_cts, tpms=tpms[rownames(raw_cts), ])
 
 se <- SummarizedExperiment(assays = count_data, colData = data_for_DE, rowData = gene_names_df)
 se <- se[, order(se$group)] # order samples by group
+
+# also output the count matrix for use with other tools
+write_tsv(as.data.frame(assays(se)$counts) |>
+            rownames_to_column("ensembl_id"), out_count_matrix)
 
 # Add vst
 dds <- DESeqDataSet(se, design = ~ group)


### PR DESCRIPTION
Upon Brandon's request for adding count matrix, I made changes to RNAseq.smk and make_sce.R. So the final result will have count_matrix file in the summarized_experiment dir. 