### PR TITLE
Better contrasts

### DIFF
--- a/config/samplesheet/comparisons.tsv
+++ b/config/samplesheet/comparisons.tsv
@@ -1,3 +1,3 @@
-comparison_name	group_test	group_reference	group_reg_formula
+comparison_name	group_test	group_reference	group_reg_formula	filterColumn	filterColumnLevel
 trt_vs_untrt	trt	untrt	~group
 

--- a/config/samplesheet/units.tsv
+++ b/config/samplesheet/units.tsv
@@ -1,4 +1,4 @@
-sample	group	fq1	fq2	RG
+sample	group	fq1	fq2	RG	filterColumn	filterColumnLevel
 SRR1039508	untrt	SRR1039508_L000_R1_001.fastq.gz	SRR1039508_L000_R2_001.fastq.gz	
 SRR1039509	trt	SRR1039509_L000_R1_001.fastq.gz	SRR1039509_L000_R2_001.fastq.gz	
 SRR1039512	untrt	SRR1039512_L000_R1_001.fastq.gz	SRR1039512_L000_R2_001.fastq.gz	

--- a/config/samplesheet/units.tsv
+++ b/config/samplesheet/units.tsv
@@ -1,4 +1,4 @@
-sample	group	fq1	fq2	RG	filterColumn	filterColumnLevel
+sample	group	fq1	fq2	RG
 SRR1039508	untrt	SRR1039508_L000_R1_001.fastq.gz	SRR1039508_L000_R2_001.fastq.gz	
 SRR1039509	trt	SRR1039509_L000_R1_001.fastq.gz	SRR1039509_L000_R2_001.fastq.gz	
 SRR1039512	untrt	SRR1039512_L000_R1_001.fastq.gz	SRR1039512_L000_R2_001.fastq.gz	

--- a/resources/deseq_template.Rmd
+++ b/resources/deseq_template.Rmd
@@ -19,6 +19,8 @@ params:
   group_test: ""
   group_reference: ""
   group_reg_formula: ""
+  filterColumn: ""
+  filterColumnLevel: ""
   fdr_cutoff: ""
   genes_of_interest: ""
   numeric_variables: ""
@@ -78,11 +80,29 @@ suppressPackageStartupMessages({
 ```{r read_se}
 se <- readRDS(paste0("../../", params$se_obj))
 
+# first subset on filterColumn==filterColumnLevel in !is.null 
+if(!is.null(colData(se)[[params$filterColumn]])){
+  se <- se[, colData(se)[[params$filterColumn]]==params$filterColumnLevel]
+  print(paste0('Filtering to ',ncol(se),' samples with ',params$filterColumn,'==',params$filterColumnLevel))
+}
+
 # subset se to just samples in this comparison (relevant esp if variance is diff between groups)
-se <- se[, colData(se)$group %in% c(params$group_test, params$group_reference)]
+formula <- trimws(params$group_reg_formula)
+formula <- sub("^~", "", formula)
+formula <- trimws(formula)
+terms <- strsplit(formula, "[+\\-*:]", perl = TRUE)[[1]]
+columnToTest <- trimws(terms[1])
+se <- se[, colData(se)[[columnToTest]] %in% c(params$group_test, params$group_reference)]
+print(paste0('Filtered to ',ncol(se),' samples with ',columnToTest,' %in% ',params$group_test,' or ',params$group_reference))
+
+# make sure we have samples left
+if (ncol(se) < 2) {
+  stop("SummarizedExperiment object has <2 samples after filtering samples.")
+}
+
 
 # factor the group column to make sure the reference group is the first level
-se$group <- factor(se$group, levels=c(params$group_reference, params$group_test))
+se[[columnToTest]] <- factor(se[[columnToTest]], levels=c(params$group_reference, params$group_test))
 
 # Convert all everything to their designated types if there are extra columns in units.tsv
 if (ncol(colData(se)) > 5 & params$numeric_variables != "" & params$numeric_variables != "None"){
@@ -111,7 +131,7 @@ se
 ```
 
 Set up analysis using counts data from the previous steps of the workflow, and 
-basic meta data given from units.tsv, with group as the variable we're testing.
+basic meta data given from units.tsv.
 **Note that covariates can be used here**; these are utilized in the `comparisons.tsv` file if you've included additional
 columns in the `units.tsv` file in the config folder. For more specialized design or analyses,
 please modify and/or contact the BBC.
@@ -205,7 +225,7 @@ Coefficients in the model are: `r paste(resultsNames(dds), collapse = ", ")`.
 After the models are fitted, we can test specific pairs of groups for differential expression. For DESeq2, it is recommended to provide the significance cutoff that you wish to use as it affects the multiple testing correction procedure (see [docs](https://www.rdocumentation.org/packages/DESeq2/versions/1.12.3/topics/results)). Here, we'll use the false discovery rate (FDR) cutoff that was provided in the config file (`r params$fdr_cutoff`).
 
 ```{r run_contrast}
-contrast <- c("group", params$group_test, params$group_reference)
+contrast <- c(columnToTest, params$group_test, params$group_reference)
 fdr_cutoff <- params$fdr_cutoff
 
 res <- results(dds, contrast=contrast, alpha=fdr_cutoff)
@@ -448,13 +468,13 @@ test_clustering <- function(in_dds, ntop) {
               as.data.frame(colData(vsd)) %>% mutate(sample = as.character(sample)),
               by="sample") 
 
-  adonis2(mat_PERMANOVA ~ group, data = mat_PERMANOVA_df, method='eu')
+  adonis2(as.formula(paste("mat_PERMANOVA ~", columnToTest)), data = mat_PERMANOVA_df, method = 'eu')
 }
 res_clustering <- test_clustering(vsd, ntop=10000)
 res_clustering
 ```
 
-The PERMANOVA test above tests whether the groups are significantly different from each other based on the most variable genes in the dataset.
+The PERMANOVA test above tests whether **`r columnToTest`** are significantly different from each other based on the most variable genes in the dataset.
 A significant p-value (e.g. < 0.05) indicates that the groups are significantly different from each other, and that the PCA plot is likely to show separation between the groups.
 Here, we see that the groups appear `r if(res_clustering[[1,"Pr(>F)"]] >= 0.05) "*not*"` to be  significantly different from each other 
 (p-value = `r format.pval(res_clustering[[1,"Pr(>F)"]], digits=3)`), indicating that the PCA plot is `r if(res_clustering[[1,"Pr(>F)"]] >= 0.05) "not"` likely to show separation between the groups.
@@ -517,9 +537,9 @@ mat <- assay(top_se, "vst")
 mat <- t(scale(t(mat), scale=FALSE, center = TRUE))
 
 # column annot
-ht_col_annot <- as.data.frame(colData(top_se)[, "group", drop=FALSE])
+ht_col_annot <- as.data.frame(colData(top_se)[, columnToTest , drop=FALSE])
 
-group_lvls <- unique(ht_col_annot$group)
+group_lvls <- unique(ht_col_annot[[columnToTest]])
 ht_col_colors <- list(group=setNames(c("#440154FF","#2A788EFF", ggsci::pal_npg()(length(group_lvls)-2)),
                                          nm=group_lvls))
 

--- a/tests/test_config/samplesheet/comparisons.tsv
+++ b/tests/test_config/samplesheet/comparisons.tsv
@@ -1,2 +1,2 @@
-comparison_name	group_test	group_reference	group_reg_formula
+comparison_name	group_test	group_reference	group_reg_formula	filterColumn	filterColumnLevel
 trt_vs_untrt	trt	untrt	~group

--- a/tests/test_test_data.py
+++ b/tests/test_test_data.py
@@ -63,12 +63,12 @@ def test_test_comparisons_match_units(repo_root, test_config):
     groups = {row["group"] for row in units}
 
     assert comparisons
-    assert {"comparison_name", "group_test", "group_reference", "group_reg_formula"} <= set(comparisons[0])
+    assert {"comparison_name", "group_test", "group_reference", "group_reg_formula", "filterColumn", "filterColumnLevel"} <= set(comparisons[0])
     for row in comparisons:
         assert row["group_test"] in groups
         assert row["group_reference"] in groups
         assert row["group_reg_formula"].startswith("~")
-
+    
 
 def test_grouped_contigs_match_reference_fai(repo_root, test_config):
     contigs = read_tsv(repo_root / test_config["grouped_contigs"])

--- a/workflow/Snakefile
+++ b/workflow/Snakefile
@@ -43,7 +43,7 @@ Rproj_packages_vals = pd.read_table("config/R_proj_packages.txt", header=None)[0
 Rproj_packages = "c('" + "','".join(Rproj_packages_vals) + "')"
 
 # comparisons: list of comparisons (contrasts) to be tested
-comparisons = pd.read_table(config["comparisons"]) 
+comparisons = pd.read_table(config["comparisons"],dtype={"filterColumnLevel": str}) 
 def get_formula_column(formula):
     # Strip whitespace, remove leading '~', take the column name
     # handles simple formulas like "~group" or "~batch + group" (takes first term)

--- a/workflow/Snakefile
+++ b/workflow/Snakefile
@@ -30,7 +30,7 @@ if not (units['fq1'].is_unique and (units['fq2'].is_unique or fq2_is_all_empty))
     raise Exception('Same fastq specified in more than one row.')
 
 
-samples = units[["sample","group"]].drop_duplicates()
+samples = units[["sample","group"]].drop_duplicates() 
 if not samples['sample'].is_unique:
     raise Exception('A sample has more than one group.')
 valid_groups = samples.groupby(['group'])['group'].count() > 1
@@ -43,9 +43,37 @@ Rproj_packages_vals = pd.read_table("config/R_proj_packages.txt", header=None)[0
 Rproj_packages = "c('" + "','".join(Rproj_packages_vals) + "')"
 
 # comparisons: list of comparisons (contrasts) to be tested
-comparisons = pd.read_table(config["comparisons"]) #, dtype={"comparison_name" : str, "group_test" : str, "group_reference" : str})
-if not (comparisons['group_test'].isin(samples['group']).all() and comparisons['group_reference'].isin(samples['group']).all()):
-    raise Exception('A group in the comparisons file is not in the samplesheet.')
+comparisons = pd.read_table(config["comparisons"]) 
+def get_formula_column(formula):
+    # Strip whitespace, remove leading '~', take the column name
+    # handles simple formulas like "~group" or "~batch + group" (takes first term)
+    formula = formula.strip().lstrip('~').strip()
+    terms = re.split(r'[+\-*:]', formula)
+    return terms[0].strip()
+
+errors = []
+for idx, row in comparisons.iterrows():
+    col = get_formula_column(row['group_reg_formula'])
+    
+    if col not in units.columns:
+        errors.append(f"Row {idx} ('{row['comparison_name']}'): column '{col}' from formula '{row['group_reg_formula']}' not found in samplesheet.")
+        continue
+    
+    valid_levels = units[col].unique()
+    
+    if row['group_test'] not in valid_levels:
+        errors.append(f"Row {idx} ('{row['comparison_name']}'): group_test '{row['group_test']}' not a level of '{col}'.")
+    if row['group_reference'] not in valid_levels:
+        errors.append(f"Row {idx} ('{row['comparison_name']}'): group_reference '{row['group_reference']}' not a level of '{col}'.")
+
+if errors:
+    raise Exception("Comparisons file validation failed:\n" + "\n".join(errors))
+
+
+
+#, dtype={"comparison_name" : str, "group_test" : str, "group_reference" : str})
+# if not (comparisons['group_test'].isin(samples['group']).all() and comparisons['group_reference'].isin(samples['group']).all()):
+    # raise Exception('A group in the comparisons file is not in the samplesheet.')
     
 
 snakemake_dir = os.getcwd() + "/"

--- a/workflow/rules/deseq2.smk
+++ b/workflow/rules/deseq2.smk
@@ -20,6 +20,8 @@ rule deseq2:
         group_test = lambda wildcards: comparisons.loc[comparisons['comparison_name'] == wildcards.comparison, 'group_test'].values[0],
         group_reference = lambda wildcards: comparisons.loc[comparisons['comparison_name'] == wildcards.comparison, 'group_reference'].values[0],
         group_reg_formula = lambda wildcards: comparisons.loc[comparisons['comparison_name'] == wildcards.comparison, 'group_reg_formula'].values[0],
+        filterColumn = lambda wildcards: comparisons.loc[comparisons['comparison_name'] == wildcards.comparison, 'filterColumn'].values[0],
+        filterColumnLevel = lambda wildcards: comparisons.loc[comparisons['comparison_name'] == wildcards.comparison, 'filterColumnLevel'].values[0],
         genes_of_interest = config['genes_of_interest'],
         numeric_vars = config['numeric_variables'],
         renv_rproj_dir = lambda wildcards, input: os.path.dirname(input.renv_lock)
@@ -41,6 +43,8 @@ rule deseq2:
                                             group_test = '{params.group_test}', 
                                             group_reference = '{params.group_reference}',
                                             group_reg_formula = '{params.group_reg_formula}',
+                                            filterColumn = '{params.filterColumn}',
+                                            filterColumnLevel = '{params.filterColumnLevel}',
                                             fdr_cutoff = {params.fdr_cutoff},
                                             genes_of_interest = '{params.genes_of_interest}',
                                             numeric_variables = '{params.numeric_vars}'))"


### PR DESCRIPTION

Made changes to Snakefile, resources/deseq_template.Rmd, workflow/rules/deseq2.smk, and units.tsv template.
Together these changes allow for easier building of contrasts including covariates (i.e. group_reg_formula can now be '~group + batch' or '~treatment + batch' etc.) and removal of 'group' as the key variable; 'group' can still be the variable tested, but now the variable is extracted from group_reg_formula (the first string following ~). This is passed dynamically to deseq2 and elsewhere where group was formerly hardcoded.
I have also added the ability to filter samples based on columnFilter==columnFilterLevel. This can be useful for subsetting which samples should be contrasted. For example, suppose you have 2 samples that are outliers and need to be removed. Add a 'filter' column in units.tsv and set it to TRUE for these two samples. Then in comparisons.tsv set columnFilter to 'filter' and columnFilterValue to '' and these two samples will be removed prior to DE analysis.
